### PR TITLE
Implement GetDiagnostics to collect diagnostic files for troubleshooting

### DIFF
--- a/app-runner/Private/DeviceProviders/DeviceProvider.ps1
+++ b/app-runner/Private/DeviceProviders/DeviceProvider.ps1
@@ -183,7 +183,7 @@ class DeviceProvider {
 
         # Filter out empty lines from the output
         if ($result) {
-            $result = $result | Where-Object { 
+            $result = $result | Where-Object {
                 if ($_ -is [string]) {
                     return $_ -and $_.Trim()
                 } else {
@@ -219,10 +219,76 @@ class DeviceProvider {
         Write-Debug "Screenshot saved to $OutputPath ($size bytes)"
     }
 
-    [hashtable] GetDiagnostics([bool]$IncludePerformanceMetrics) {
-        Write-Debug "$($this.Platform): Getting diagnostics (include performance: $IncludePerformanceMetrics)"
-        # TODO screenshot, logs, etc.
-        return @{}
+    [hashtable] GetDiagnostics([string]$OutputDirectory) {
+        Write-Debug "$($this.Platform): Collecting diagnostics to directory: $OutputDirectory"
+
+        # Ensure output directory exists
+        if (-not (Test-Path $OutputDirectory)) {
+            New-Item -Path $OutputDirectory -ItemType Directory -Force | Out-Null
+        }
+
+        $datePrefix = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $results = @{
+            Platform  = $this.Platform
+            Timestamp = Get-Date
+            Files     = @()
+        }
+
+        # Collect device status
+        try {
+            $statusFile = Join-Path $OutputDirectory "$datePrefix-device-status.json"
+            $status = $this.GetDeviceStatus()
+            $status | ConvertTo-Json -Depth 10 | Out-File -FilePath $statusFile -Encoding UTF8
+            $results.Files += $statusFile
+            Write-Debug "Device status saved to: $statusFile"
+        } catch {
+            Write-Warning "Failed to collect device status: $_"
+        }
+
+        # Take screenshot
+        try {
+            $screenshotFile = Join-Path $OutputDirectory "$datePrefix-screenshot.png"
+            $this.TakeScreenshot($screenshotFile)
+            $results.Files += $screenshotFile
+            Write-Debug "Screenshot saved to: $screenshotFile"
+        } catch {
+            Write-Warning "Failed to capture screenshot: $_"
+        }
+
+        # Collect device logs (if available)
+        try {
+            # Try to get logs - this may not be implemented on all platforms
+            if ($this.PSObject.Methods['GetDeviceLogs']) {
+                $logsFile = Join-Path $OutputDirectory "$datePrefix-device-logs.json"
+                $logs = $this.GetDeviceLogs('All', 1000)
+                if ($logs -and $logs.Count -gt 0) {
+                    $logs | ConvertTo-Json -Depth 10 | Out-File -FilePath $logsFile -Encoding UTF8
+                    $results.Files += $logsFile
+                    Write-Debug "Device logs saved to: $logsFile"
+                }
+            }
+        } catch {
+            Write-Debug "Device logs not available or failed to collect: $_"
+        }
+
+        # Collect system information
+        try {
+            $sysInfoFile = Join-Path $OutputDirectory "$datePrefix-system-info.txt"
+            $sysInfo = @"
+Platform: $($this.Platform)
+Device Identifier: $($this.GetDeviceIdentifier())
+Collection Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+SDK Path: $($this.SdkPath)
+"@
+            $sysInfo | Out-File -FilePath $sysInfoFile -Encoding UTF8
+            $results.Files += $sysInfoFile
+            Write-Debug "System info saved to: $sysInfoFile"
+        } catch {
+            Write-Warning "Failed to collect system information: $_"
+        }
+
+        Write-Debug "Diagnostics collection complete. Files saved: $($results.Files.Count)"
+        return $results
     }
 
     [string] GetDeviceIdentifier() {

--- a/app-runner/Tests/Diagnostics.Tests.ps1
+++ b/app-runner/Tests/Diagnostics.Tests.ps1
@@ -19,27 +19,67 @@ AfterAll {
 }
 
 Context 'Get-DeviceDiagnostics' {
-    It 'Should require device session' {
-        Disconnect-Device
-        { Get-DeviceDiagnostics } | Should -Throw '*No active device session*'
+    BeforeEach {
+        $TestOutputDir = Join-Path $TestDrive "diagnostics-$(Get-Random)"
     }
 
-    It 'Should accept IncludePerformanceMetrics switch' {
+    It 'Should require device session' {
+        Disconnect-Device
+        { Get-DeviceDiagnostics -OutputDirectory $TestOutputDir } | Should -Throw '*No active device session*'
+    }
+
+    It 'Should accept OutputDirectory parameter' {
         $Function = Get-Command Get-DeviceDiagnostics
-        $Function.Parameters.Keys | Should -Contain 'IncludePerformanceMetrics'
+        $Function.Parameters.Keys | Should -Contain 'OutputDirectory'
     }
 
     It 'Should work with active session' {
         Connect-Device -Platform 'Mock'
-        { Get-DeviceDiagnostics } | Should -Not -Throw
+        { Get-DeviceDiagnostics -OutputDirectory $TestOutputDir } | Should -Not -Throw
     }
 
     It 'Should return diagnostics object with expected properties' {
         Connect-Device -Platform 'Mock'
-        $diagnostics = Get-DeviceDiagnostics -IncludePerformanceMetrics
+        $diagnostics = Get-DeviceDiagnostics -OutputDirectory $TestOutputDir
         $diagnostics | Should -Not -Be $null
         $diagnostics.Platform | Should -Be 'Mock'
         $diagnostics.Timestamp | Should -Not -Be $null
+        $diagnostics.Files | Should -Not -Be $null
+    }
+
+    It 'Should create diagnostic files in the output directory' {
+        Connect-Device -Platform 'Mock'
+        $diagnostics = Get-DeviceDiagnostics -OutputDirectory $TestOutputDir
+        $TestOutputDir | Should -Exist
+        $diagnostics.Files.Count | Should -BeGreaterThan 0
+
+        foreach ($file in $diagnostics.Files) {
+            $file | Should -Exist
+        }
+    }
+
+    It 'Should create files with correct naming format (yyyyMMdd-HHmmss-subject.ext)' {
+        Connect-Device -Platform 'Mock'
+        $diagnostics = Get-DeviceDiagnostics -OutputDirectory $TestOutputDir
+        $datePrefix = Get-Date -Format "yyyyMMdd"
+
+        foreach ($file in $diagnostics.Files) {
+            $filename = Split-Path $file -Leaf
+            $filename | Should -Match "^$datePrefix-\d{6}-.*\.\w+$"
+        }
+    }
+
+    It 'Should use current directory when OutputDirectory not specified' {
+        Connect-Device -Platform 'Mock'
+        New-Item -Path $TestOutputDir -ItemType Directory -Force | Out-Null
+        Push-Location $TestOutputDir
+        try {
+            $diagnostics = Get-DeviceDiagnostics
+            $diagnostics.Files | Should -Not -Be $null
+            $diagnostics.Files.Count | Should -BeGreaterThan 0
+        } finally {
+            Pop-Location
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Implements proper diagnostic collection for `GetDiagnostics` to help troubleshoot test and app runtime failures on console devices.

## Changes
- **DeviceProvider.ps1**: Implemented `GetDiagnostics` to collect:
  - Device status (JSON)
  - Screenshots (PNG)
  - Device logs (JSON, platform-dependent)
  - System information (TXT)
  - Files named with format: `yyyyMMdd-HHmmss-<subject>.<extension>`

- **MockDeviceProvider.ps1**: Added mock implementation for testing

- **Get-DeviceDiagnostics.ps1**: Updated public API to accept `OutputDirectory` parameter instead of boolean flag

- **Tests**: Added comprehensive unit tests (using Pester TestDrive) and integration tests for real platforms (Switch, PlayStation5, Xbox)

## Test Plan
- [x] Unit tests pass (9 tests in Diagnostics.Tests.ps1)
- [x] Integration tests pass (6 tests in Device.Tests.ps1)
- [x] Verified diagnostic collection on real Switch, PlayStation5, and Xbox devices
- [x] Verified files are created with correct naming format
- [x] Verified file contents are valid (JSON parsing, platform info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)