### PR TITLE
fix: Pass `--platform` param to set default Switch (Ounce) targets

### DIFF
--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -146,26 +146,39 @@ class SwitchProvider : DeviceProvider {
                 }
             }
 
+            # Recovery steps are best-effort: if one fails, continue to the next
             switch ($i) {
                 0 {
-                    Write-Warning 'Attempting to wake up the Devkit from sleep...'
-                    $this.InvokeCommand('press-power-button', @())
+                    try {
+                        Write-Warning 'Attempting to wake up the Devkit from sleep...'
+                        $this.InvokeCommand('press-power-button', @())
+                    } catch {
+                        Write-Warning "Failed to wake up Devkit: $_"
+                    }
                 }
                 1 {
-                    Write-Warning 'Attempting to start the Devkit...'
-                    $this.StartDevice()
+                    try {
+                        Write-Warning 'Attempting to start the Devkit...'
+                        $this.StartDevice()
+                    } catch {
+                        Write-Warning "Failed to start Devkit: $_"
+                    }
                 }
                 2 {
-                    Write-Warning 'Attempting to reboot the Devkit...'
-                    $powerOffCmd = $this.BuildCommand('poweroff', @()).Command
-                    $powerOnCmd = $this.BuildCommand('poweron', @()).Command
-                    $job2 = Start-Job {
-                        param($offCmd, $onCmd)
-                        Invoke-Expression $offCmd
-                        Start-Sleep -Seconds 5
-                        Invoke-Expression $onCmd
-                    } -ArgumentList $powerOffCmd, $powerOnCmd
-                    Wait-Job $job2 -Timeout 20 | Out-Null
+                    try {
+                        Write-Warning 'Attempting to reboot the Devkit...'
+                        $powerOffCmd = $this.BuildCommand('poweroff', @()).Command
+                        $powerOnCmd = $this.BuildCommand('poweron', @()).Command
+                        $job2 = Start-Job {
+                            param($offCmd, $onCmd)
+                            Invoke-Expression $offCmd
+                            Start-Sleep -Seconds 5
+                            Invoke-Expression $onCmd
+                        } -ArgumentList $powerOffCmd, $powerOnCmd
+                        Wait-Job $job2 -Timeout 20 | Out-Null
+                    } catch {
+                        Write-Warning "Failed to reboot Devkit: $_"
+                    }
                 }
                 3 {
                     if ($info.IpAddress -ne $null) {

--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -44,7 +44,7 @@ class SwitchProvider : DeviceProvider {
             'reset'              = @($this.TargetControlTool, 'reset')
             'getstatus'          = @($this.TargetControlTool, 'get-default --detail --json', { $input | ConvertFrom-Json })
             'get-default-target' = @($this.TargetControlTool, 'get-default --json', { $input | ConvertFrom-Json })
-            'set-default-target' = @($this.TargetControlTool, 'set-default --target "{0}"')
+            'set-default-target' = @($this.TargetControlTool, 'set-default --target "{0}" --platform {1}')
             'list-target'        = @($this.TargetControlTool, 'list-target --json', { $input | ConvertFrom-Json })
             'detect-target'      = @($this.TargetControlTool, 'detect-target --json', { $input | ConvertFrom-Json })
             'register-target'    = @($this.TargetControlTool, 'register --target "{0}"')
@@ -66,7 +66,12 @@ class SwitchProvider : DeviceProvider {
         if (-not [string]::IsNullOrEmpty($target)) {
             Write-Debug "$($this.Platform): Setting target device: $target"
             $this.Target = $target
-            $this.InvokeCommand('set-default-target', @($target))
+
+            # Target Manager 2 requires the platform to be specified explicitly.
+            # Platform can be inferred from the target name (HAL* targets are Ounce/Switch 2, others are NX/Switch 1).
+            $platform = if ($target -match '^HAL') { 'Ounce' } else { 'NX' }
+
+            $this.InvokeCommand('set-default-target', @($target, $platform))
         }
         return $this.Connect()
     }

--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -176,6 +176,12 @@ class SwitchProvider : DeviceProvider {
             throw 'Failed to connect to the Switch Devkit.'
         }
 
+        # Verify the device is actually connected after recovery attempts
+        $finalStatus = $this.GetDeviceStatus().StatusData
+        if ("$($finalStatus.Status)" -ne 'Connected') {
+            throw "Failed to connect to the Switch Devkit. Device status: $($finalStatus.Status)"
+        }
+
         Write-Debug 'Successfully connected to the Switch Devkit.'
         return $this.CreateSessionInfo()
     }

--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -17,6 +17,7 @@ class SwitchProvider : DeviceProvider {
     [string]$TargetControlTool = 'ControlTarget.exe'
     [string]$ApplicationRunnerTool = 'RunOnTarget.exe'
     [string]$Target = $null  # Stores the target device identifier for commands that need explicit --target
+    [string]$TargetPlatform = $null  # Target Manager platform: 'NX' or 'Ounce', resolved from target serial
 
     SwitchProvider() {
         $this.Platform = 'Switch'
@@ -42,7 +43,7 @@ class SwitchProvider : DeviceProvider {
             'poweroff'           = @($this.TargetControlTool, 'power-off')
             'press-power-button' = @($this.TargetControlTool, 'press-power-button')
             'reset'              = @($this.TargetControlTool, 'reset')
-            'getstatus'          = @($this.TargetControlTool, 'get-default --detail --json', { $input | ConvertFrom-Json })
+            'getstatus'          = @($this.TargetControlTool, 'get-default --detail --platform {0} --json', { $input | ConvertFrom-Json })
             'get-default-target' = @($this.TargetControlTool, 'get-default --json', { $input | ConvertFrom-Json })
             'set-default-target' = @($this.TargetControlTool, 'set-default --target "{0}" --platform {1}')
             'list-target'        = @($this.TargetControlTool, 'list-target --json', { $input | ConvertFrom-Json })
@@ -69,11 +70,36 @@ class SwitchProvider : DeviceProvider {
 
             # Target Manager 2 requires the platform to be specified explicitly.
             # Platform can be inferred from the target name (HAL* targets are Ounce/Switch 2, others are NX/Switch 1).
-            $platform = if ($target -match '^HAL') { 'Ounce' } else { 'NX' }
+            $this.TargetPlatform = if ($target -match '^HAL') { 'Ounce' } else { 'NX' }
+            Write-Debug "$($this.Platform): Using Target Manager platform: $($this.TargetPlatform)"
 
-            $this.InvokeCommand('set-default-target', @($target, $platform))
+            $this.InvokeCommand('set-default-target', @($target, $this.TargetPlatform))
         }
         return $this.Connect()
+    }
+
+    # Override DetectAndSetDefaultTarget to skip auto-detection when target was explicitly set in Connect
+    [void] DetectAndSetDefaultTarget() {
+        if (-not [string]::IsNullOrEmpty($this.Target)) {
+            Write-Debug "$($this.Platform): Target explicitly set to $($this.Target), skipping auto-detection"
+            return
+        }
+        ([DeviceProvider] $this).DetectAndSetDefaultTarget()
+    }
+
+    # Override GetDeviceStatus to include `--platform` arg when querying device status so that it works correctly when multiple platforms are registered
+    [hashtable] GetDeviceStatus() {
+        Write-Debug "$($this.Platform): Getting device status"
+
+        $platform = if ($this.TargetPlatform) { $this.TargetPlatform } else { 'NX' }
+        $result = $this.InvokeCommand('getstatus', @($platform))
+
+        return @{
+            Platform   = $this.Platform
+            Status     = 'Online'
+            StatusData = $result
+            Timestamp  = Get-Date
+        }
     }
 
     # Override Connect to provide Switch specific wakeup

--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -102,6 +102,12 @@ class SwitchProvider : DeviceProvider {
         }
     }
 
+    [bool] TestConnection() {
+        Write-Debug "$($this.Platform): Testing connection to device"
+        $this.GetDeviceStatus()
+        return $true
+    }
+
     # Override Connect to provide Switch specific wakeup
     [hashtable] Connect() {
         Write-Debug 'Connecting to Switch Devkit...'

--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -73,6 +73,16 @@ class SwitchProvider : DeviceProvider {
             $this.TargetPlatform = if ($target -match '^HAL') { 'Ounce' } else { 'NX' }
             Write-Debug "$($this.Platform): Using Target Manager platform: $($this.TargetPlatform)"
 
+            # Update device-control commands to include --target so they operate on the correct device
+            # when multiple targets (NX and Ounce) are registered in Target Manager.
+            $targetArg = " --target `"$target`""
+            $this.Commands['connect'] = @($this.TargetControlTool, "connect --force$targetArg")
+            $this.Commands['disconnect'] = @($this.TargetControlTool, "disconnect$targetArg")
+            $this.Commands['poweron'] = @($this.TargetControlTool, "power-on$targetArg")
+            $this.Commands['poweroff'] = @($this.TargetControlTool, "power-off$targetArg")
+            $this.Commands['press-power-button'] = @($this.TargetControlTool, "press-power-button$targetArg")
+            $this.Commands['reset'] = @($this.TargetControlTool, "reset$targetArg")
+
             $this.InvokeCommand('set-default-target', @($target, $this.TargetPlatform))
         }
         return $this.Connect()

--- a/app-runner/Private/DeviceProviders/SwitchProvider.ps1
+++ b/app-runner/Private/DeviceProviders/SwitchProvider.ps1
@@ -147,18 +147,25 @@ class SwitchProvider : DeviceProvider {
                 }
                 2 {
                     Write-Warning 'Attempting to reboot the Devkit...'
+                    $powerOffCmd = $this.BuildCommand('poweroff', @()).Command
+                    $powerOnCmd = $this.BuildCommand('poweron', @()).Command
                     $job2 = Start-Job {
-                        ControlTarget power-off
+                        param($offCmd, $onCmd)
+                        Invoke-Expression $offCmd
                         Start-Sleep -Seconds 5
-                        ControlTarget power-on
-                    }
+                        Invoke-Expression $onCmd
+                    } -ArgumentList $powerOffCmd, $powerOnCmd
                     Wait-Job $job2 -Timeout 20 | Out-Null
                 }
                 3 {
                     if ($info.IpAddress -ne $null) {
                         Write-Warning 'Attempting to reboot host bridge...'
-                        Invoke-WebRequest -Uri "http://$($info.IpAddress)/cgi-bin/config?reboot"
-                        $nextTimeout = 300 # This takes a long time so wait longer next time
+                        try {
+                            Invoke-WebRequest -Uri "http://$($info.IpAddress)/cgi-bin/config?reboot"
+                            $nextTimeout = 300 # This takes a long time so wait longer next time
+                        } catch {
+                            Write-Warning "Failed to reboot host bridge: $_"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Target Manager 2 maintains separate default targets per platform (NX vs Ounce). Without `--platform` arg, `ControlTarget` commands default to NX, which fails for Ounce (Switch 2) devices.

## Key Changes

- `set-default-target` / `getstatus`: Add `--platform` parameter to command templates, inferred from target serial prefix (`HAL*` = Ounce, else NX)
- `DetectAndSetDefaultTarget()`: Skip auto-detection when target was explicitly set in `Connect([string]$target)`, since `set-default` was already called with the correct platform
- `GetDeviceStatus()` / `TestConnection()`: Override to pass `--platform` so status queries return the correct device info