### PR TITLE
Add session replay API helpers

### DIFF
--- a/sentry-api-client/Public/Get-SentryReplay.ps1
+++ b/sentry-api-client/Public/Get-SentryReplay.ps1
@@ -1,0 +1,37 @@
+function Get-SentryReplay {
+    <#
+    .SYNOPSIS
+    Retrieves a specific session replay from Sentry.
+
+    .DESCRIPTION
+    Fetches detailed information about a specific Sentry session replay by its ID
+    (duration, segment count, associated trace IDs, timestamps, etc.).
+    Automatically removes hyphens from GUID-formatted replay IDs.
+
+    .PARAMETER ReplayId
+    The unique identifier of the replay to retrieve. Can be provided with or without hyphens.
+
+    .EXAMPLE
+    Get-SentryReplay -ReplayId "7acc9c0d4a2e0a85187fe9b75e6b05ac"
+    # Retrieves the replay with the given ID
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReplayId
+    )
+
+    # Remove hyphens from GUID-formatted replay IDs
+    $ReplayId = $ReplayId -replace '-', ''
+
+    $Uri = Get-SentryProjectUrl -Resource "replays/$ReplayId/"
+
+    $Response = Invoke-SentryApiRequest -Uri $Uri -Method 'GET'
+
+    # The replay instance endpoint wraps the payload in a 'data' envelope
+    if ($Response -is [hashtable] -and $Response.ContainsKey('data')) {
+        return $Response.data
+    }
+
+    return $Response
+}

--- a/sentry-api-client/SentryApiClient.psd1
+++ b/sentry-api-client/SentryApiClient.psd1
@@ -40,6 +40,7 @@
         'Get-SentryLogsByAttribute',
         'Get-SentryMetrics',
         'Get-SentryMetricsByAttribute',
+        'Get-SentryReplay',
         'Get-SentrySpans',
         'Invoke-SentryCLI'
     )

--- a/utils/Integration.TestUtils.psm1
+++ b/utils/Integration.TestUtils.psm1
@@ -514,5 +514,54 @@ function Get-SentryTestEventAttachments {
     throw "Expected at least $ExpectedCount attachment(s) for event $EventId but found $foundCount within $TimeoutSeconds seconds. Last error: $lastError"
 }
 
+function Get-SentryTestReplay {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReplayId,
+
+        [Parameter()]
+        [int]$TimeoutSeconds = 300
+    )
+
+    Write-Host "Fetching Sentry replay by ID: $ReplayId" -ForegroundColor Yellow
+    $progressActivity = "Waiting for Sentry replay $ReplayId"
+
+    $startTime = Get-Date
+    $endTime = $startTime.AddSeconds($TimeoutSeconds)
+    $lastError = $null
+    $elapsedSeconds = 0
+
+    try {
+        do {
+            $sentryReplay = $null
+            $elapsedSeconds = [int]((Get-Date) - $startTime).TotalSeconds
+            $percentComplete = [math]::Min(100, ($elapsedSeconds / $TimeoutSeconds) * 100)
+
+            Write-Progress -Activity $progressActivity -Status "Elapsed: $elapsedSeconds/$TimeoutSeconds seconds" -PercentComplete $percentComplete
+
+            try {
+                $sentryReplay = Get-SentryReplay -ReplayId $ReplayId
+            } catch {
+                $lastError = $_.Exception.Message
+                Write-Debug "Replay $ReplayId not found yet: $lastError"
+            }
+
+            if ($sentryReplay) {
+                Write-Host "Replay $($sentryReplay.id) fetched from Sentry" -ForegroundColor Green
+                $sentryReplay | ConvertTo-Json -Depth 10 | Out-File -FilePath (Get-OutputFilePath "replay-$($sentryReplay.id).json")
+                return $sentryReplay
+            }
+
+            Start-Sleep -Milliseconds 500
+            $currentTime = Get-Date
+        } while ($currentTime -lt $endTime)
+    } finally {
+        Write-Progress -Activity $progressActivity -Completed
+    }
+
+    throw "Replay $ReplayId not found in Sentry within $TimeoutSeconds seconds: $lastError"
+}
+
 # Export module functions
-Export-ModuleMember -Function Invoke-CMakeConfigure, Invoke-CMakeBuild, Set-OutputDir, Get-OutputFilePath, Get-EventIds, Get-SentryTestEvent, Get-SentryTestEventAttachments, Get-SentryTestLog, Get-SentryTestMetric, Get-SentryTestTransaction, Get-PackageAumid
+Export-ModuleMember -Function Invoke-CMakeConfigure, Invoke-CMakeBuild, Set-OutputDir, Get-OutputFilePath, Get-EventIds, Get-SentryTestEvent, Get-SentryTestEventAttachments, Get-SentryTestLog, Get-SentryTestMetric, Get-SentryTestTransaction, Get-SentryTestReplay, Get-PackageAumid


### PR DESCRIPTION
Adds `Get-SentryReplay` to the Sentry API client that fetches a replay instance via `GET /projects/{org}/{project}/replays/{replay_id}/` (duration, segment count, trace/error associations, timestamps) and a `Get-SentryTestReplay` polling wrapper in `Integration.TestUtils.psm1`, following the existing event/log/metric helper patterns.

Needed by the session replay integration test for getsentry/sentry-unreal#1445, where the native crash daemon delivers a staged replay as a `replay_video` envelope alongside a crash and the test verifies it was ingested and linked to the crash event. Verified end-to-end against a real Sentry project.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1445