### PR TITLE
Add replay recording segments API helpers

### DIFF
--- a/sentry-api-client/Public/Get-SentryReplayRecordingSegments.ps1
+++ b/sentry-api-client/Public/Get-SentryReplayRecordingSegments.ps1
@@ -27,14 +27,13 @@ function Get-SentryReplayRecordingSegments {
 
     $Uri = Get-SentryProjectUrl -Resource "replays/$ReplayId/recording-segments/" -QueryString "download=true"
 
-    $Response = Invoke-SentryApiRequest -Uri $Uri -Method 'GET'
-
-    # The endpoint returns an array with one entry per segment. Pipeline
-    # enumeration collapses a single-segment response into its inner rrweb
-    # event list on the way here, so detect that case (elements are event
-    # dictionaries rather than segment lists) and re-wrap it. The comma
-    # operator prevents the same unwrapping on return.
-    $Segments = @($Response)
+    # The endpoint returns an array with one entry per segment. Wrapping the
+    # call in `@(...)` collects an empty response into an empty array rather
+    # than `$null`. Pipeline enumeration collapses a single-segment response
+    # into its inner rrweb event list on the way here, so detect that case
+    # (elements are event dictionaries rather than segment lists) and re-wrap
+    # it. The comma operator prevents the same unwrapping on return.
+    $Segments = @(Invoke-SentryApiRequest -Uri $Uri -Method 'GET')
     if ($Segments.Count -gt 0 -and $Segments[0] -is [System.Collections.IDictionary]) {
         $Segments = , $Segments
     }

--- a/sentry-api-client/Public/Get-SentryReplayRecordingSegments.ps1
+++ b/sentry-api-client/Public/Get-SentryReplayRecordingSegments.ps1
@@ -1,0 +1,31 @@
+function Get-SentryReplayRecordingSegments {
+    <#
+    .SYNOPSIS
+    Retrieves the recording segments of a session replay from Sentry.
+
+    .DESCRIPTION
+    Fetches the rrweb recording data of a Sentry session replay by its ID.
+    The response is a JSON array with one entry per segment; each entry is the
+    segment's list of rrweb events (video metadata, breadcrumbs, etc.).
+    Automatically removes hyphens from GUID-formatted replay IDs.
+
+    .PARAMETER ReplayId
+    The unique identifier of the replay. Can be provided with or without hyphens.
+
+    .EXAMPLE
+    Get-SentryReplayRecordingSegments -ReplayId "7acc9c0d4a2e0a85187fe9b75e6b05ac"
+    # Retrieves the rrweb events of all recording segments of the given replay
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReplayId
+    )
+
+    # Remove hyphens from GUID-formatted replay IDs
+    $ReplayId = $ReplayId -replace '-', ''
+
+    $Uri = Get-SentryProjectUrl -Resource "replays/$ReplayId/recording-segments/" -QueryString "download=true"
+
+    return Invoke-SentryApiRequest -Uri $Uri -Method 'GET'
+}

--- a/sentry-api-client/Public/Get-SentryReplayRecordingSegments.ps1
+++ b/sentry-api-client/Public/Get-SentryReplayRecordingSegments.ps1
@@ -27,5 +27,17 @@ function Get-SentryReplayRecordingSegments {
 
     $Uri = Get-SentryProjectUrl -Resource "replays/$ReplayId/recording-segments/" -QueryString "download=true"
 
-    return Invoke-SentryApiRequest -Uri $Uri -Method 'GET'
+    $Response = Invoke-SentryApiRequest -Uri $Uri -Method 'GET'
+
+    # The endpoint returns an array with one entry per segment. Pipeline
+    # enumeration collapses a single-segment response into its inner rrweb
+    # event list on the way here, so detect that case (elements are event
+    # dictionaries rather than segment lists) and re-wrap it. The comma
+    # operator prevents the same unwrapping on return.
+    $Segments = @($Response)
+    if ($Segments.Count -gt 0 -and $Segments[0] -is [System.Collections.IDictionary]) {
+        $Segments = , $Segments
+    }
+
+    return , $Segments
 }

--- a/sentry-api-client/SentryApiClient.psd1
+++ b/sentry-api-client/SentryApiClient.psd1
@@ -41,6 +41,7 @@
         'Get-SentryMetrics',
         'Get-SentryMetricsByAttribute',
         'Get-SentryReplay',
+        'Get-SentryReplayRecordingSegments',
         'Get-SentrySpans',
         'Invoke-SentryCLI'
     )

--- a/utils/Integration.TestUtils.psm1
+++ b/utils/Integration.TestUtils.psm1
@@ -598,7 +598,8 @@ function Get-SentryTestReplayRecordingSegments {
 
             if ($segments -and @($segments).Count -gt 0) {
                 Write-Host "Recording segments for replay $ReplayId fetched from Sentry" -ForegroundColor Green
-                $segments | ConvertTo-Json -Depth 10 | Out-File -FilePath (Get-OutputFilePath "replay-recording-$ReplayId.json")
+                # Pass as -InputObject so a single-segment array is not enumerated away
+                ConvertTo-Json -InputObject $segments -Depth 10 | Out-File -FilePath (Get-OutputFilePath "replay-recording-$ReplayId.json")
                 # Use comma operator to ensure array is preserved (prevents PowerShell unwrapping single item)
                 return , @($segments)
             }

--- a/utils/Integration.TestUtils.psm1
+++ b/utils/Integration.TestUtils.psm1
@@ -563,5 +563,54 @@ function Get-SentryTestReplay {
     throw "Replay $ReplayId not found in Sentry within $TimeoutSeconds seconds: $lastError"
 }
 
+function Get-SentryTestReplayRecordingSegments {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReplayId,
+
+        [Parameter()]
+        [int]$TimeoutSeconds = 300
+    )
+
+    Write-Host "Fetching Sentry replay recording segments for replay: $ReplayId" -ForegroundColor Yellow
+    $progressActivity = "Waiting for Sentry replay recording segments of $ReplayId"
+
+    $startTime = Get-Date
+    $endTime = $startTime.AddSeconds($TimeoutSeconds)
+    $lastError = $null
+    $elapsedSeconds = 0
+
+    try {
+        do {
+            $segments = $null
+            $elapsedSeconds = [int]((Get-Date) - $startTime).TotalSeconds
+            $percentComplete = [math]::Min(100, ($elapsedSeconds / $TimeoutSeconds) * 100)
+
+            Write-Progress -Activity $progressActivity -Status "Elapsed: $elapsedSeconds/$TimeoutSeconds seconds" -PercentComplete $percentComplete
+
+            try {
+                $segments = Get-SentryReplayRecordingSegments -ReplayId $ReplayId
+            } catch {
+                $lastError = $_.Exception.Message
+                Write-Debug "Recording segments for replay $ReplayId not found yet: $lastError"
+            }
+
+            if ($segments -and @($segments).Count -gt 0) {
+                Write-Host "Recording segments for replay $ReplayId fetched from Sentry" -ForegroundColor Green
+                $segments | ConvertTo-Json -Depth 10 | Out-File -FilePath (Get-OutputFilePath "replay-recording-$ReplayId.json")
+                return $segments
+            }
+
+            Start-Sleep -Milliseconds 500
+            $currentTime = Get-Date
+        } while ($currentTime -lt $endTime)
+    } finally {
+        Write-Progress -Activity $progressActivity -Completed
+    }
+
+    throw "Recording segments for replay $ReplayId not found in Sentry within $TimeoutSeconds seconds: $lastError"
+}
+
 # Export module functions
-Export-ModuleMember -Function Invoke-CMakeConfigure, Invoke-CMakeBuild, Set-OutputDir, Get-OutputFilePath, Get-EventIds, Get-SentryTestEvent, Get-SentryTestEventAttachments, Get-SentryTestLog, Get-SentryTestMetric, Get-SentryTestTransaction, Get-SentryTestReplay, Get-PackageAumid
+Export-ModuleMember -Function Invoke-CMakeConfigure, Invoke-CMakeBuild, Set-OutputDir, Get-OutputFilePath, Get-EventIds, Get-SentryTestEvent, Get-SentryTestEventAttachments, Get-SentryTestLog, Get-SentryTestMetric, Get-SentryTestTransaction, Get-SentryTestReplay, Get-SentryTestReplayRecordingSegments, Get-PackageAumid

--- a/utils/Integration.TestUtils.psm1
+++ b/utils/Integration.TestUtils.psm1
@@ -599,7 +599,8 @@ function Get-SentryTestReplayRecordingSegments {
             if ($segments -and @($segments).Count -gt 0) {
                 Write-Host "Recording segments for replay $ReplayId fetched from Sentry" -ForegroundColor Green
                 $segments | ConvertTo-Json -Depth 10 | Out-File -FilePath (Get-OutputFilePath "replay-recording-$ReplayId.json")
-                return $segments
+                # Use comma operator to ensure array is preserved (prevents PowerShell unwrapping single item)
+                return , @($segments)
             }
 
             Start-Sleep -Milliseconds 500


### PR DESCRIPTION
This PR adds API helpers for fetching a session replay's rrweb recording data, so integration tests can assert on recording contents (e.g. embedded breadcrumbs):

- `Get-SentryReplayRecordingSegments` (sentry-api-client): fetches the recording segments of a replay via the `recording-segments/?download=true` endpoint; the response is a JSON array with one entry per segment, each entry being the segment's list of rrweb events.
- `Get-SentryTestReplayRecordingSegments` (Integration.TestUtils): polling wrapper following the `Get-SentryTestReplay` pattern, saving the fetched recording to the test output directory.

### Testing

Verified end-to-end by getsentry/sentry-unreal#1480, which uses these helpers to assert that breadcrumbs are embedded in crash replay recordings — the Session Replay integration test context passes on Windows against the live Sentry API.
