### PR TITLE
ci: Replace secrets: inherit with explicit Sauce Labs secret pass

### DIFF
--- a/.github/workflows/app-runner.yml
+++ b/.github/workflows/app-runner.yml
@@ -14,7 +14,9 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test-powershell-module.yml
-    secrets: inherit
+    secrets:
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
     with:
       module-name: SentryAppRunner
       module-path: app-runner

--- a/.github/workflows/test-powershell-module.yml
+++ b/.github/workflows/test-powershell-module.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: 'PSScriptAnalyzerSettings.psd1'
+    secrets:
+      SAUCE_USERNAME:
+        required: false
+      SAUCE_ACCESS_KEY:
+        required: false
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- The `test` job in `app-runner.yml` used `secrets: inherit` when calling `test-powershell-module.yml`, exposing every repository secret to that workflow.
- `test-powershell-module.yml` only reads `secrets.SAUCE_USERNAME` and `secrets.SAUCE_ACCESS_KEY` (for Sauce Labs test runs) but never declared them under `workflow_call.secrets`.
- Declared both explicitly in `test-powershell-module.yml` and updated `app-runner.yml` to pass only those secrets by name.

## Test plan
- [x] Confirmed `test-powershell-module.yml` only references `secrets.SAUCE_USERNAME` and `secrets.SAUCE_ACCESS_KEY`
- [x] Validated workflow YAML parses correctly
- [ ] Verify the `test` job still runs correctly on this PR

Fixes VULN-2318

🤖 Generated with [Claude Code](https://claude.com/claude-code)